### PR TITLE
Set up local dev vs prod MongoUI keys

### DIFF
--- a/.env.mongo
+++ b/.env.mongo
@@ -1,1 +1,1 @@
-MONGO_URI=mongodb://localhost:27017/skellybot-local
+MONGODB_URI=mongodb://localhost:27017/skellybot-local

--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -2,12 +2,16 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { GcpModule } from '../gcp/gcp.module';
 import { UsersModule } from './schema/users/users.module';
-import { DatabaseConnectionService } from './services/database-connection.service';
+import { DatabaseConfigService } from './services/database-config.service';
 
 @Module({
   imports: [
     GcpModule,
-    MongooseModule.forRoot('mongodb://localhost:27017/test'),
+
+    MongooseModule.forRootAsync({
+      imports: [GcpModule],
+      useClass: DatabaseConfigService,
+    }),
     // CatsModule,
     UsersModule,
   ],

--- a/src/core/database/services/database-config.service.ts
+++ b/src/core/database/services/database-config.service.ts
@@ -1,41 +1,32 @@
 import { Injectable } from '@nestjs/common';
-import { NecordModuleOptions } from 'necord';
-import { IntentsBitField } from 'discord.js';
 import { ConfigService } from '@nestjs/config';
 import { GcpSecretsService } from '../../gcp/gcp-secrets.service';
+import { MongooseModuleOptions } from '@nestjs/mongoose';
 
 @Injectable()
-export class DiscordConfigService {
+export class DatabaseConfigService {
   private _tokenMap = {
-    DISCORD_BOT_TOKEN:
-      'projects/588063171007/secrets/DISCORD_BOT_TOKEN/versions/latest',
+    MONGODB_URI: 'projects/588063171007/secrets/MONGODB_URI/versions/latest',
   };
   constructor(
     private readonly sms: GcpSecretsService,
     private readonly _cfgService: ConfigService,
   ) {}
 
-  async createNecordOptions(): Promise<NecordModuleOptions> {
-    const token = await this._createTokenByNodeEnv();
-    return {
-      token,
-      intents: [
-        IntentsBitField.Flags.Guilds,
-        IntentsBitField.Flags.GuildMessages,
-        IntentsBitField.Flags.MessageContent,
-      ],
-    };
+  async createMongooseOptions(): Promise<MongooseModuleOptions> {
+    const uri = await this._getUriByNodeEnv();
+    return { uri };
   }
 
-  private async _createTokenByNodeEnv() {
-    if (process.env.NODE_ENV === 'production') {
-      const secretName = this._tokenMap.DISCORD_BOT_TOKEN;
+  private async _getUriByNodeEnv() {
+    if (process.env.NODE_ENV === 'production' || true) {
+      const secretName = this._tokenMap.MONGODB_URI;
       const [secret] = await this.sms.getSecretsManager().accessSecretVersion({
         name: secretName,
       });
       return secret.payload.data.toString();
     }
 
-    return this._cfgService.getOrThrow('DISCORD_BOT_TOKEN');
+    return this._cfgService.getOrThrow('MONGODB_URI');
   }
 }


### PR DESCRIPTION
If dev environment, use local UI in `env.mongo`. If prod, use a MongoDB Atlas Cluster URI (hosted by @jonmatthis, we can move it to GCP later)