### PR TITLE
Add basic functional-enough method to set system prompt from context

### DIFF
--- a/src/core/ai/langchain/langchain.service.ts
+++ b/src/core/ai/langchain/langchain.service.ts
@@ -38,7 +38,11 @@ export class LangchainService {
     const prompt = ChatPromptTemplate.fromMessages([
       [
         'system',
-        `${contextInstructionsOrNone} I keep my answers short (1-2 sentences) unless there is a reason to say more.`,
+        // TODO - set the `contextInstructions` to be a PromptVariable thing that is set each time the chain is called (like human text input)
+        // https://js.langchain.com/docs/expression_language/cookbook/adding_memory
+        // https://js.langchain.com/docs/expression_language/how_to/message_history
+
+        `${contextInstructionsOrNone} \n\nI keep my answers short (1-2 sentences) unless there is a reason to say more.`,
       ],
       new MessagesPlaceholder('history'),
       ['human', '{input}'],
@@ -103,6 +107,7 @@ export class LangchainService {
 
     console.log(`HumanInput:\n\n ${inputs.input}`);
 
+    // TODO - Figure out how to add additional arguments to the chain (i.e. like the topic/ {contextInstructions} thing)
     const response = await chain.invoke({
       input: 'Hello botto - say an emoji',
     });

--- a/src/core/ai/langchain/langchain.service.ts
+++ b/src/core/ai/langchain/langchain.service.ts
@@ -29,13 +29,16 @@ export class LangchainService {
     return this._model;
   }
 
-  public async createBufferMemoryChain(modelName?: string) {
+  public async createBufferMemoryChain(
+    modelName?: string,
+    contextInstructions?: string,
+  ) {
     const model = await this._createModel(modelName);
+    const contextInstructionsOrNone = contextInstructions || ' ';
     const prompt = ChatPromptTemplate.fromMessages([
-      // TODO: Feed in a context prompt key
       [
         'system',
-        'I am a helpful chatbot. I keep my answers short (1-2 sentences) unless there is a reason to say more.',
+        `${contextInstructionsOrNone} I keep my answers short (1-2 sentences) unless there is a reason to say more.`,
       ],
       new MessagesPlaceholder('history'),
       ['human', '{input}'],
@@ -100,7 +103,9 @@ export class LangchainService {
 
     console.log(`HumanInput:\n\n ${inputs.input}`);
 
-    const response = await chain.invoke(inputs);
+    const response = await chain.invoke({
+      input: 'Hello botto - say an emoji',
+    });
 
     console.log(`AI Response:\n\n ${response}`);
 

--- a/src/core/bot/bot.service.ts
+++ b/src/core/bot/bot.service.ts
@@ -17,12 +17,19 @@ export class BotService {
     private readonly _langchainService: LangchainService,
   ) {}
 
-  public async createBot(chatbotId: string, modelName?: string) {
+  public async createBot(
+    chatbotId: string,
+    modelName?: string,
+    contextInstructions?: string,
+  ) {
     this._logger.log(
       `Creating chatbot with id: ${chatbotId} and language model (llm): ${modelName}`,
     );
     const { chain, memory } =
-      await this._langchainService.createBufferMemoryChain(modelName);
+      await this._langchainService.createBufferMemoryChain(
+        modelName,
+        contextInstructions,
+      );
 
     const chatbot = { chain, memory } as Chatbot;
     this._chatbots.set(chatbotId, chatbot);

--- a/src/interfaces/discord/services/discord-thread.service.ts
+++ b/src/interfaces/discord/services/discord-thread.service.ts
@@ -51,7 +51,11 @@ export class DiscordThreadService implements OnModuleDestroy {
     });
 
     // await this._botService.createChatbot(thread.id);
-    await this._botService.createBot(thread.id);
+    await this._botService.createBot(
+      thread.id,
+      'gpt-4-1106-preview',
+      channel.topic || '',
+    );
 
     this._beginWatchingIncomingMessages(interaction, channel, thread);
     await this._sendInitialReply(interaction, channel, thread, text);


### PR DESCRIPTION
In Discord, we pull `channel.topic` 

Later, we'll want to also grab `category` and `server` level #bot-config channel descriptions/messages for full hierarchical prompting 

Current method just pulls `channel.topic` at chain initialization, which is ok enough for now but problematic because it won't update if/when those values change later 