### PR TITLE
Hierarchical context instructions, baybee - channel, category, server

### DIFF
--- a/src/interfaces/discord/discord.module.ts
+++ b/src/interfaces/discord/discord.module.ts
@@ -11,6 +11,7 @@ import { BotModule } from '../../core/bot/bot.module';
 import { AiChatsModule } from '../../core/database/collections/ai-chats/ai-chats.module';
 import { CoupletsModule } from '../../core/database/collections/couplets/couplets.module';
 import { MessagesModule } from '../../core/database/collections/messages/messages.module';
+import { DiscordContextService } from './services/discord-context.service';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { MessagesModule } from '../../core/database/collections/messages/message
     DiscordPingService,
     DiscordThreadService,
     DiscordReadyService,
+    DiscordContextService,
     Logger,
   ],
 })

--- a/src/interfaces/discord/services/discord-context.service.ts
+++ b/src/interfaces/discord/services/discord-context.service.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import { ReactionEmoji, TextChannel, ThreadChannel } from 'discord.js';
+import { DiscordContextRouteFactory } from '../../../core/database/collections/ai-chats/context-route.provider';
+
+@Injectable()
+export class DiscordContextService {
+  getContextRoute(channel: TextChannel, thread?: ThreadChannel) {
+    // TODO - Handle Direct Messages
+    return DiscordContextRouteFactory.create(
+      false,
+      {
+        type: 'channel',
+        contextId: channel.id,
+        contextName: channel.name,
+      },
+      {
+        type: 'server',
+        contextId: channel.guild?.id,
+        contextName: channel.guild?.name,
+      },
+      {
+        type: 'category',
+        contextId: channel?.parentId,
+        contextName: channel.parent?.name,
+      },
+      {
+        type: 'thread',
+        contextId: thread?.id,
+        contextName: thread?.name,
+      },
+    );
+  }
+
+  async getContextInstructions(channel: TextChannel) {
+    const channelInstructions = channel.topic || '';
+    const categoryInstructions = await this.getCategoryInstructions(channel);
+    const serverInstructions = await this.getServerInstructions(channel);
+    return [serverInstructions, categoryInstructions, channelInstructions].join(
+      '\n\n',
+    );
+  }
+
+  private async getCategoryInstructions(channel: TextChannel): Promise<string> {
+    const category = channel.parent;
+    if (!category) {
+      return '';
+    }
+    const categoryChannels = channel.guild.channels.cache.filter(
+      (ch) => ch.parentId === channel.parentId,
+    );
+
+    const botConfigChannel = categoryChannels.find((ch) =>
+      /bot-config.*?/i.test(ch.name),
+    ) as TextChannel | undefined;
+    if (!botConfigChannel) {
+      return '';
+    }
+
+    const messages = await botConfigChannel.messages.fetch({ limit: 100 });
+
+    const instructionMessages = messages.filter((message) =>
+      message.reactions.cache.some((reaction) =>
+        // @ts-ignore
+        this.isBotInstructionEmoji(reaction.emoji),
+      ),
+    );
+
+    const instructions = instructionMessages
+      .map((message) => message.content)
+      .join('\n');
+
+    return instructions;
+  }
+
+  private async getServerInstructions(channel: TextChannel): Promise<string> {
+    if (!channel.guild) {
+      return '';
+    }
+    const topLevelChannels = channel.guild.channels.cache.filter(
+      (ch) => !ch.parent, // only get channels that are not in a category
+    );
+
+    const botConfigChannel = topLevelChannels.find((ch) =>
+      /bot-config.*?/i.test(ch.name),
+    ) as TextChannel | undefined;
+    if (!botConfigChannel) {
+      return '';
+    }
+
+    const messages = await botConfigChannel.messages.fetch({ limit: 100 });
+
+    const instructionMessages = messages.filter((message) =>
+      message.reactions.cache.some((reaction) =>
+        // @ts-ignore
+        this.isBotInstructionEmoji(reaction.emoji),
+      ),
+    );
+
+    const instructions = instructionMessages
+      .map((message) => message.content)
+      .join('\n');
+
+    return instructions;
+  }
+  private isBotInstructionEmoji(emoji: ReactionEmoji): boolean {
+    return emoji.name === '🤖';
+  }
+}

--- a/src/interfaces/discord/services/discord-thread.service.ts
+++ b/src/interfaces/discord/services/discord-thread.service.ts
@@ -14,6 +14,7 @@ import { DiscordContextRouteFactory } from '../../../core/database/collections/a
 import { AiChatsService } from '../../../core/database/collections/ai-chats/ai-chats.service';
 import { CoupletsService } from '../../../core/database/collections/couplets/couplets.service';
 import { MessagesService } from '../../../core/database/collections/messages/messages.service';
+import { DiscordContextService } from './discord-context.service';
 
 @Injectable()
 export class DiscordThreadService implements OnModuleDestroy {
@@ -22,6 +23,7 @@ export class DiscordThreadService implements OnModuleDestroy {
     private readonly _usersService: UsersService,
     private readonly _coupletService: CoupletsService,
     private readonly _messageService: MessagesService,
+    private readonly _contextService: DiscordContextService,
     private readonly _logger: Logger,
     private readonly _botService: BotService,
     private readonly _client: Client,
@@ -53,8 +55,9 @@ export class DiscordThreadService implements OnModuleDestroy {
       reason: 'wow this is a thread',
     });
 
-    const contextRoute = this._getContextRoute(channel, thread);
-    const contextInstructions = this._getContextInstructions(channel);
+    const contextRoute = this._contextService.getContextRoute(channel, thread);
+    const contextInstructions =
+      await this._contextService.getContextInstructions(channel);
     this._logger.log(
       `Creating bot with contextInstructions: \n ''' \n ${contextInstructions}\n '''`,
     );


### PR DESCRIPTION
On Bot creation : 
- grab channel.topic

- Looks for channels called `bot-config` within:
    - the originating channel's category and 
    - at top level (channels w/o categories) and 

- pulls the content of messages tagged with a 🤖 reaction

-  concatenates `server`, `category`,`channel` prompts into `contextInstructions`
- puts them in the System prompt of the new chain